### PR TITLE
Update README.md and improve CameraManager initialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .env
-/.venv
+/venv
 __pycache__/
 **/__pycache__/
 **.db

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ python -m src.main
 Hoặc nếu bạn trên macOS/Linux và Python 3 là `python3`:
 
 ```bash
-python3 -m src.main.py```
+python3 -m src.main```
 
 
 ---

--- a/README.md
+++ b/README.md
@@ -40,19 +40,19 @@ Tạo môi trường ảo để tránh xung đột package.
 
 Windows (PowerShell):
 ```bash
-python -m venv .venv
-./.venv/Scripts/Activate.ps1
+python -m venv venv
+./venv/Scripts/Activate.ps1
 ```
 Windows (cmd):
 ```bash
-python -m venv .venv
-.\.venv\Scripts\activate
+python -m venv venv
+.\venv\Scripts\activate
 ```
 
 macOS / Linux:
 ```bash
-python3 -m venv .venv
-source .venv/bin/activate
+python3 -m venv venv
+source venv/bin/activate
 ```
 
 ---
@@ -98,13 +98,13 @@ Lưu ý: tên biến tùy thuộc vào cách project bạn implement — kiểm 
 ### Bước 6: Chạy ứng dụng (Cần phải chạy module)
 Từ thư mục gốc của dự án, chạy:
 ```bash
-python -m src.main
+python -m src.main.py
 ```
 
 Hoặc nếu bạn trên macOS/Linux và Python 3 là `python3`:
 
 ```bash
-python3 -m src/main.py```
+python3 -m src.main.py```
 
 
 ---
@@ -149,4 +149,4 @@ Facedetection_Robofolow/
 
 ## 🔒 Bảo mật
 - Không commit file `.env` chứa api_key hoặc secret lên public repo.
-- Sử dụng `.gitignore` để loại trừ `.env` và folder `.venv`.
+- Sử dụng `.gitignore` để loại trừ `.env` và folder `venv`.

--- a/README.md
+++ b/README.md
@@ -40,19 +40,19 @@ Tạo môi trường ảo để tránh xung đột package.
 
 Windows (PowerShell):
 ```bash
-python -m venv .venv
-./.venv/Scripts/Activate.ps1
+python -m venv venv
+./venv/Scripts/Activate.ps1
 ```
 Windows (cmd):
 ```bash
-python -m venv .venv
-.\.venv\Scripts\activate
+python -m venv venv
+.\venv\Scripts\activate
 ```
 
 macOS / Linux:
 ```bash
-python3 -m venv .venv
-source .venv/bin/activate
+python3 -m venv venv
+source venv/bin/activate
 ```
 
 ---
@@ -98,13 +98,13 @@ Lưu ý: tên biến tùy thuộc vào cách project bạn implement — kiểm 
 ### Bước 6: Chạy ứng dụng (Cần phải chạy module)
 Từ thư mục gốc của dự án, chạy:
 ```bash
-python -m src/main.py
+python -m src.main.py
 ```
 
 Hoặc nếu bạn trên macOS/Linux và Python 3 là `python3`:
 
 ```bash
-python3 -m src/main.py```
+python3 -m src.main.py```
 
 
 ---
@@ -149,4 +149,4 @@ Facedetection_Robofolow/
 
 ## 🔒 Bảo mật
 - Không commit file `.env` chứa api_key hoặc secret lên public repo.
-- Sử dụng `.gitignore` để loại trừ `.env` và folder `.venv`.
+- Sử dụng `.gitignore` để loại trừ `.env` và folder `venv`.

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Lưu ý: tên biến tùy thuộc vào cách project bạn implement — kiểm 
 ### Bước 6: Chạy ứng dụng (Cần phải chạy module)
 Từ thư mục gốc của dự án, chạy:
 ```bash
-python -m src.main.py
+python -m src.main
 ```
 
 Hoặc nếu bạn trên macOS/Linux và Python 3 là `python3`:

--- a/src/database/db.py
+++ b/src/database/db.py
@@ -35,7 +35,7 @@ def init_db():
     if count == 0:
         users = [
             ("Thong Senpai", "123456", "Hello world"),
-            ("Tam Cter", "baque", "Tribeti"),
+            ("TamCter", "baque", "Tribeti"),
             ("Thong", "123123", "Notepad siêu cấp"),
             ("Huy", "363636", "Notepad content")
         ]

--- a/src/main.py
+++ b/src/main.py
@@ -18,17 +18,17 @@ inference = InferenceService(
 )
 
 root = Tk()
-cam = CameraManager()
 
 def face_detection():
 
+    cam = CameraManager()
     cam.start()
 
     infer = InferenceWorker(
         camera=cam,
         inference_engine=inference,
         callback=lambda label, conf: show_notepad(root, frm, User(label)),
-        timeout=60,
+        timeout=10,
         interval=0.2
     )
 

--- a/src/services/camera_manager.py
+++ b/src/services/camera_manager.py
@@ -3,8 +3,8 @@ import threading
 import time
 
 class CameraManager:
-    def __init__(self, camera_source=0):
-        self.cap = cv2.VideoCapture(camera_source)
+    def __init__(self, camera_source=1):
+        self.cap = cv2.VideoCapture(camera_source, cv2.CAP_DSHOW)
         self.running = False
         self.frame = None
         self.lock = threading.Lock()

--- a/src/services/camera_manager.py
+++ b/src/services/camera_manager.py
@@ -3,7 +3,7 @@ import threading
 import time
 
 class CameraManager:
-    def __init__(self, camera_source=1):
+    def __init__(self, camera_source=0):
         self.cap = cv2.VideoCapture(camera_source, cv2.CAP_DSHOW)
         self.running = False
         self.frame = None


### PR DESCRIPTION
- Changed virtual environment directory name from `.venv` to `venv` in README.md.
- Updated the command to run the main application in README.md.
- Modified user entry in the database to remove space in username.
- Adjusted CameraManager initialization to use camera source 1 and added CAP_DSHOW flag.
- Reduced timeout for inference worker from 60 to 10 seconds.